### PR TITLE
Fix/gcc 11 support

### DIFF
--- a/src/backend/backend.cpp
+++ b/src/backend/backend.cpp
@@ -15,7 +15,7 @@
 #include <GL/glx.h>
 #include <GL/glext.h>
 
-#include <format>
+#include <string>
 #include <cmath>
 #include <cstring>
 
@@ -117,7 +117,7 @@ Backend::Backend()
                 actionType = XR_ACTION_TYPE_VIBRATION_OUTPUT;
                 break;
         }
-        OpenXR::Action* action = new OpenXR::Action(*this->actionSet, std::format("input_{}", i), std::format("Input {}", i), actionType, {});
+        OpenXR::Action* action = new OpenXR::Action(*this->actionSet, "input_" + std::to_string(i), "Input " + std::to_string(i), actionType, {});
         this->actions.push_back(action);
         OpenXR::ActionSet::ActionBinding binding(*action, inputs[i].path);
         actionSetBindings.push_back(binding);

--- a/src/backend/input_profile.h
+++ b/src/backend/input_profile.h
@@ -10,6 +10,8 @@ namespace vapor
     class InputProfile
     {
         public:
+            virtual ~InputProfile() = default;
+
             virtual std::string getOpenXRInteractionProfileName() = 0;
             virtual int getOpenXRInputsCount() = 0;
             virtual const OpenXRInputDescription* getOpenXRInputs() = 0;

--- a/src/backend/openxr.cpp
+++ b/src/backend/openxr.cpp
@@ -97,7 +97,7 @@ Session::Session(const Instance& instance, XrSystemId system): instance(instance
         ABORT("Failed to open X11 display");
     }
     int fbConfigsCounts;
-    GLXFBConfig* fbConfigs = glXChooseFBConfig(this->xDisplay, DefaultScreen(this->xDisplay), (int[]) {
+    int configsAttribList[] = {
         GLX_X_RENDERABLE, True,
         GLX_DRAWABLE_TYPE, GLX_PBUFFER_BIT,
         GLX_RENDER_TYPE, GLX_RGBA_BIT,
@@ -107,7 +107,8 @@ Session::Session(const Instance& instance, XrSystemId system): instance(instance
         GLX_ALPHA_SIZE, 8,
         GLX_DEPTH_SIZE, 24,
         None
-    }, &fbConfigsCounts);
+    };
+    GLXFBConfig* fbConfigs = glXChooseFBConfig(this->xDisplay, DefaultScreen(this->xDisplay), configsAttribList, &fbConfigsCounts);
     if (!fbConfigs || fbConfigsCounts == 0)
     {
         ABORT("Failed to find framebuffer configuration");
@@ -118,11 +119,12 @@ Session::Session(const Instance& instance, XrSystemId system): instance(instance
     if (!this->glxContext) {
         ABORT("Failed to create OpenGL context");
     }
-    this->glxPbuffer = glXCreatePbuffer(this->xDisplay, fbConfig, (int[]) {
+    int bufferAttribList[] = {
         GLX_WIDTH, 16,
         GLX_HEIGHT, 16,
         None
-    });
+    };
+    this->glxPbuffer = glXCreatePbuffer(this->xDisplay, fbConfig, bufferAttribList);
     if (!this->glxPbuffer)
     {
         ABORT("Failed to create OpenGL pbuffer");

--- a/src/openvr/impl/utils/pose.h
+++ b/src/openvr/impl/utils/pose.h
@@ -6,6 +6,8 @@
 
 #include "matrix.h"
 
+#include <cstring>
+
 namespace openvr
 {
     namespace utils
@@ -69,7 +71,8 @@ namespace openvr
 
         inline void applyOffset(TrackedDevicePose* trackedDevicePose, const float (&offsetMatrix)[3][4])
         {
-            if (offsetMatrix == (float[3][4]) {{1.0f, 0.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 1.0f, 0.0f}})
+            static const float identityOffset[3][4] = {{1.0f, 0.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 1.0f, 0.0f}};
+            if (std::memcmp(offsetMatrix, identityOffset, sizeof(identityOffset)) == 0)
             {
                 return;
             }


### PR DESCRIPTION
Changes required to package in flatpak and target up to PopOS! (gcc 11).

* <format> header is not present in the libstdc++
* compiler warning pick up the comparison between arrays using pointers
* compound literals fail as trying to take address of a temporary

Not needed for gcc11 support, but I saw the warning about delete called on InputProfile, which does not have a virtual destructor.